### PR TITLE
Add order creation

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -106,6 +106,65 @@ paths:
                 required:
                   - result
                   - size
+  /orders:
+    post:
+      summary: Create a new order
+      operationId: createOrder
+      description: Create a new order.
+      tags:
+        - Orders
+      requestBody:
+        description: The order to create.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: object
+                    properties:
+                      productId:
+                        $ref: '#/components/schemas/Product'
+                      quantity:
+                        type: integer
+                    required:
+                      - productId
+                      - quantity
+                cardDetails:
+                  $ref: '#/components/schemas/CardDetails'
+              required:
+                - items
+                - cardDetails
+      responses:
+        '201':
+          description: The order has been created successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    $ref: '#/components/schemas/Order'
+                required:
+                  - result
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '500':
+          description: An error occurred while processing the order.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: 'An error occurred while processing the order.'
+                required:
+                  - error
 components:
   parameters:
     paginationOffset:
@@ -127,6 +186,51 @@ components:
         default: 25
       description: The numbers of items to return.
   schemas:
+    CardDetails:
+      type: object
+      properties:
+        cardNumber:
+          type: string
+          description: The card number.
+        expiryMonth:
+          type: string
+          format: 01-12
+          description: The card expiration month (MM).
+        expiryYear:
+          type: string
+          format: 0000-9999
+          description: The card expiration year (YYYY).
+        cvv:
+          type: string
+          format: 000-999
+          description: The card CVV (XXX).
+      required:
+        - cardNumber
+        - expiryMonth
+        - expiryYear
+        - cvv
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: The order ID.
+          readOnly: true
+        amount:
+          type: number
+          format: float
+          description: The total amount of the order.
+          readOnly: true
+        transactionId:
+          type: string
+          description: The transaction ID.
+          format: uuid
+          readOnly: true
+      required:
+        - id
+        - amount
+        - transactionId
     Category:
       type: object
       properties:
@@ -189,4 +293,4 @@ components:
           schema:
             type: string
             example: 'Invalid parameters or request body.'
-security: []
+security: [ ]

--- a/src/controllers/order.ts
+++ b/src/controllers/order.ts
@@ -1,0 +1,34 @@
+import { Elysia } from 'elysia';
+import { setup } from '../setup.ts';
+import { orderRequestBody } from '../models/order.ts';
+import { OrderService } from '../services/order.ts';
+
+export const orders = new Elysia({
+    name: 'Controller.Orders',
+    prefix: '/orders',
+})
+    .use(setup)
+    .post(
+        '/',
+        async ({ body, set, error }) => {
+            try {
+                const order = await OrderService.createOrder(body.items, body.cardDetails);
+
+                set.status = 201;
+                return {
+                    result: order,
+                };
+            } catch (err) {
+                console.error(err);
+
+                if (err instanceof Error) {
+                    return error(422, {
+                        error: err.message,
+                    });
+                }
+            }
+        },
+        {
+            body: orderRequestBody,
+        },
+    );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { Elysia } from 'elysia';
 import { products } from './controllers/products.ts';
 import { categories } from './controllers/category.ts';
+import { orders } from './controllers/order.ts';
 
-const app = new Elysia({ prefix: '/api' }).use(products).use(categories).listen(3000);
+const app = new Elysia({ prefix: '/api' }).use(products).use(categories).use(orders).listen(3000);
 
 console.log(`🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`);

--- a/src/libs/database.ts
+++ b/src/libs/database.ts
@@ -1,16 +1,11 @@
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
-import type { SQLiteSelect } from 'drizzle-orm/sqlite-core';
 import * as products from '../schema/products.ts';
 import * as categories from '../schema/categories.ts';
+import * as orders from '../schema/orders.ts';
+import * as ordersToProducts from '../schema/ordersToProducts.ts';
 
 const sqlite = new Database('data/sqlite.db');
-export const db = drizzle(sqlite, { schema: { ...products, ...categories } });
-
-export const withPagination = <T extends SQLiteSelect>(
-    query: T,
-    page: number,
-    pageSize: number,
-) => {
-    return query.limit(pageSize).offset(page * pageSize);
-};
+export const db = drizzle(sqlite, {
+    schema: { ...products, ...categories, ...orders, ...ordersToProducts },
+});

--- a/src/models/order.ts
+++ b/src/models/order.ts
@@ -1,0 +1,17 @@
+import { type Static, t } from 'elysia';
+import { cardDetails } from './payment.ts';
+import { orders } from '../schema/orders.ts';
+
+export type Order = typeof orders.$inferSelect;
+
+const cartItem = t.Object({
+    productId: t.Numeric({ minimum: 0 }),
+    quantity: t.Numeric({ minimum: 1 }),
+});
+
+export type CartItem = Static<typeof cartItem>;
+
+export const orderRequestBody = t.Object({
+    items: t.Array(cartItem, { minItems: 1 }),
+    cardDetails,
+});

--- a/src/models/payment.ts
+++ b/src/models/payment.ts
@@ -1,0 +1,25 @@
+import { type Static, t } from 'elysia';
+
+export const cardDetails = t.Object({
+    cardNumber: t.RegExp(/\b\d{16}\b/),
+    expiryMonth: t.RegExp(/\b(0[1-9]|1[0-2])\b/),
+    expiryYear: t.RegExp(/\b\d{4}\b/),
+    cvv: t.RegExp(/\b\d{3}\b/),
+});
+
+export type CardDetails = Static<typeof cardDetails>;
+
+export type ProcessPaymentRequest = {
+    amount: number;
+    cardDetails: CardDetails;
+};
+
+export type ProcessPaymentResponse = {
+    transactionId: string;
+    status: 'approved' | 'declined' | 'error';
+};
+
+export type ProcessPaymentErrorResponse = {
+    code: number;
+    message: string;
+};

--- a/src/schema/orders.ts
+++ b/src/schema/orders.ts
@@ -1,0 +1,13 @@
+import { integer, sqliteTable, real, text } from 'drizzle-orm/sqlite-core';
+import { relations } from 'drizzle-orm';
+import { ordersToProducts } from './ordersToProducts.ts';
+
+export const orders = sqliteTable('orders', {
+    id: integer('id').primaryKey(),
+    amount: real('amount').notNull(),
+    transactionId: text('transactionId').notNull(),
+});
+
+export const ordersRelations = relations(orders, ({ many }) => ({
+    ordersToProducts: many(ordersToProducts),
+}));

--- a/src/schema/ordersToProducts.ts
+++ b/src/schema/ordersToProducts.ts
@@ -1,0 +1,27 @@
+import { integer, sqliteTable, primaryKey } from 'drizzle-orm/sqlite-core';
+import { relations } from 'drizzle-orm';
+import { products } from './products.ts';
+import { orders } from './orders.ts';
+
+export const ordersToProducts = sqliteTable(
+    'orders_to_products',
+    {
+        productId: integer('product_id').notNull(),
+        orderId: integer('order_id').notNull(),
+        quantity: integer('quantity').notNull(),
+    },
+    (t) => ({
+        pk: primaryKey({ columns: [t.productId, t.orderId] }),
+    }),
+);
+
+export const ordersToProductsRelations = relations(ordersToProducts, ({ one }) => ({
+    product: one(products, {
+        fields: [ordersToProducts.productId],
+        references: [products.id],
+    }),
+    order: one(orders, {
+        fields: [ordersToProducts.orderId],
+        references: [orders.id],
+    }),
+}));

--- a/src/schema/products.ts
+++ b/src/schema/products.ts
@@ -1,6 +1,7 @@
 import { text, integer, sqliteTable, real } from 'drizzle-orm/sqlite-core';
 import { categories } from './categories.ts';
 import { relations } from 'drizzle-orm';
+import { ordersToProducts } from './ordersToProducts.ts';
 
 export const products = sqliteTable('products', {
     id: integer('id').primaryKey(),
@@ -13,9 +14,10 @@ export const products = sqliteTable('products', {
         .notNull(),
 });
 
-export const productsRelations = relations(products, ({ one }) => ({
+export const productsRelations = relations(products, ({ one, many }) => ({
     category: one(categories, {
         fields: [products.category],
         references: [categories.id],
     }),
+    ordersToProducts: many(ordersToProducts),
 }));

--- a/src/services/order.ts
+++ b/src/services/order.ts
@@ -1,0 +1,66 @@
+import { db } from '../libs/database.ts';
+import type { CartItem, Order } from '../models/order.ts';
+import { orders } from '../schema/orders.ts';
+import { ordersToProducts } from '../schema/ordersToProducts.ts';
+import { products } from '../schema/products.ts';
+import { and, eq, gte, sql } from 'drizzle-orm';
+import type { CardDetails } from '../models/payment.ts';
+import { PaymentService } from './payment.ts';
+
+export abstract class OrderService {
+    public static async createOrder(items: CartItem[], cardDetails: CardDetails): Promise<Order> {
+        return db.transaction(async (tx) => {
+            let amount = 0;
+            for (const item of items) {
+                const [product] = await tx
+                    .update(products)
+                    .set({ stockQuantity: sql`stock_quantity - ${item.quantity}` })
+                    .where(
+                        and(
+                            eq(products.id, item.productId),
+                            gte(products.stockQuantity, item.quantity),
+                        ),
+                    )
+                    .returning({ id: products.id, price: products.price });
+                if (!product) {
+                    throw new Error(
+                        `Product with ID ${item.productId} is not available in the required quantity`,
+                    );
+                }
+
+                amount += product.price * item.quantity;
+            }
+
+            const paymentResponse = await PaymentService.processPayment({
+                amount,
+                cardDetails,
+            });
+
+            const [order] = await tx
+                .insert(orders)
+                .values([
+                    {
+                        amount,
+                        transactionId: paymentResponse.transactionId,
+                    },
+                ])
+                .returning();
+
+            if (paymentResponse.status === 'declined') {
+                throw new Error('Payment declined');
+            } else if (paymentResponse.status === 'error') {
+                throw new Error('Payment error');
+            }
+
+            for (const item of items) {
+                await tx
+                    .insert(ordersToProducts)
+                    .values([
+                        { orderId: order.id, productId: item.productId, quantity: item.quantity },
+                    ]);
+            }
+
+            return order;
+        });
+    }
+}

--- a/src/services/payment.ts
+++ b/src/services/payment.ts
@@ -1,0 +1,36 @@
+import type {
+    ProcessPaymentRequest,
+    ProcessPaymentResponse /*ProcessPaymentErrorResponse*/,
+} from '../models/payment.ts';
+import { randomUUID } from 'node:crypto';
+
+export abstract class PaymentService {
+    /*public static async processPayment(processPaymentRequest: ProcessPaymentRequest): Promise<ProcessPaymentResponse | ProcessPaymentErrorResponse> {
+        try {
+            const response = await fetch('https://paymentservice.example.com/api/payment', {
+                method: 'POST',
+                body: JSON.stringify(processPaymentRequest),
+                headers: {
+                    "Content-Type": "application/json",
+                }
+            });
+
+            return response.json();
+        } catch(err) {
+            console.error('Error processing payment', err);
+
+            throw err;
+        }
+    }*/
+
+    public static async processPayment(
+        processPaymentRequest: ProcessPaymentRequest,
+    ): Promise<ProcessPaymentResponse> {
+        console.info('Processing payment...', processPaymentRequest);
+
+        return {
+            transactionId: randomUUID(),
+            status: Math.random() > 0.5 ? 'approved' : 'declined',
+        };
+    }
+}


### PR DESCRIPTION
closes #5.

This PR adds order related controller, service, schema and models.

`POST /api/orders` accepts a list of product ids with their desidered quantity and the details of the credit card.
If the payment is successful and there are enough items in the stock, it creates a new order and returns it, otherwise it returns an error.