### PR TITLE
Add reward program

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -191,7 +191,8 @@ components:
       properties:
         cardNumber:
           type: string
-          description: The card number.
+          description: The card number. Must be 16 digits. If this is set to `1111111111111111`, the payment will succeed, otherwise it will fail.
+          example: 1111111111111111
         expiryMonth:
           type: string
           format: 01-12

--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -136,6 +136,11 @@ paths:
                       - quantity
                 cardDetails:
                   $ref: '#/components/schemas/CardDetails'
+                rewardPoints:
+                  type: integer
+                  description: The reward points to use for the order.
+                  minimum: 0
+                  default: 0
               required:
                 - items
                 - cardDetails
@@ -165,6 +170,26 @@ paths:
                     example: 'An error occurred while processing the order.'
                 required:
                   - error
+  /rewards:
+    get:
+      summary: Get the reward points balance
+      operationId: getRewardPointsBalance
+      description: Get the reward points balance.
+      tags:
+        - Rewards
+      responses:
+        '200':
+          description: The reward points balance.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: integer
+                    description: The reward points balance.
+                required:
+                  - result
 components:
   parameters:
     paginationOffset:

--- a/src/controllers/order.ts
+++ b/src/controllers/order.ts
@@ -12,7 +12,11 @@ export const orders = new Elysia({
         '/',
         async ({ body, set, error }) => {
             try {
-                const order = await OrderService.createOrder(body.items, body.cardDetails);
+                const order = await OrderService.createOrder(
+                    body.items,
+                    body.cardDetails,
+                    body.rewardPoints,
+                );
 
                 set.status = 201;
                 return {

--- a/src/controllers/reward.ts
+++ b/src/controllers/reward.ts
@@ -1,0 +1,16 @@
+import { Elysia } from 'elysia';
+import { setup } from '../setup.ts';
+import { RewardService } from '../services/reward.ts';
+
+export const rewards = new Elysia({
+    name: 'Controller.Rewards',
+    prefix: '/rewards',
+})
+    .use(setup)
+    .get('/', async () => {
+        const balance = await RewardService.getRewardsBalance();
+
+        return {
+            result: balance,
+        };
+    });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,13 @@ import { Elysia } from 'elysia';
 import { products } from './controllers/products.ts';
 import { categories } from './controllers/category.ts';
 import { orders } from './controllers/order.ts';
+import { rewards } from './controllers/reward.ts';
 
-const app = new Elysia({ prefix: '/api' }).use(products).use(categories).use(orders).listen(3000);
+const app = new Elysia({ prefix: '/api' })
+    .use(products)
+    .use(categories)
+    .use(orders)
+    .use(rewards)
+    .listen(3000);
 
 console.log(`🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`);

--- a/src/libs/database.ts
+++ b/src/libs/database.ts
@@ -4,8 +4,9 @@ import * as products from '../schema/products.ts';
 import * as categories from '../schema/categories.ts';
 import * as orders from '../schema/orders.ts';
 import * as ordersToProducts from '../schema/ordersToProducts.ts';
+import * as rewards from '../schema/rewards.ts';
 
 const sqlite = new Database('data/sqlite.db');
 export const db = drizzle(sqlite, {
-    schema: { ...products, ...categories, ...orders, ...ordersToProducts },
+    schema: { ...products, ...categories, ...orders, ...ordersToProducts, ...rewards },
 });

--- a/src/models/order.ts
+++ b/src/models/order.ts
@@ -13,5 +13,6 @@ export type CartItem = Static<typeof cartItem>;
 
 export const orderRequestBody = t.Object({
     items: t.Array(cartItem, { minItems: 1 }),
+    rewardPoints: t.Optional(t.Numeric({ minimum: 0 })),
     cardDetails,
 });

--- a/src/schema/orders.ts
+++ b/src/schema/orders.ts
@@ -1,13 +1,15 @@
 import { integer, sqliteTable, real, text } from 'drizzle-orm/sqlite-core';
 import { relations } from 'drizzle-orm';
 import { ordersToProducts } from './ordersToProducts.ts';
+import { rewards } from './rewards.ts';
 
 export const orders = sqliteTable('orders', {
     id: integer('id').primaryKey(),
     amount: real('amount').notNull(),
-    transactionId: text('transactionId').notNull(),
+    transactionId: text('transaction_id').notNull(),
 });
 
 export const ordersRelations = relations(orders, ({ many }) => ({
     ordersToProducts: many(ordersToProducts),
+    rewards: many(rewards),
 }));

--- a/src/schema/ordersToProducts.ts
+++ b/src/schema/ordersToProducts.ts
@@ -6,8 +6,12 @@ import { orders } from './orders.ts';
 export const ordersToProducts = sqliteTable(
     'orders_to_products',
     {
-        productId: integer('product_id').notNull(),
-        orderId: integer('order_id').notNull(),
+        productId: integer('product_id')
+            .references(() => products.id)
+            .notNull(),
+        orderId: integer('order_id')
+            .references(() => orders.id)
+            .notNull(),
         quantity: integer('quantity').notNull(),
     },
     (t) => ({

--- a/src/schema/products.ts
+++ b/src/schema/products.ts
@@ -12,6 +12,7 @@ export const products = sqliteTable('products', {
     category: integer('category_id')
         .references(() => categories.id)
         .notNull(),
+    extraRewardPoints: integer('extra_reward_points').notNull().default(0),
 });
 
 export const productsRelations = relations(products, ({ one, many }) => ({

--- a/src/schema/rewards.ts
+++ b/src/schema/rewards.ts
@@ -1,0 +1,18 @@
+import { integer, sqliteTable } from 'drizzle-orm/sqlite-core';
+import { relations } from 'drizzle-orm';
+import { orders } from './orders.ts';
+
+export const rewards = sqliteTable('rewards', {
+    id: integer('id').primaryKey(),
+    amount: integer('amount').notNull(),
+    orderId: integer('order_id')
+        .references(() => orders.id)
+        .notNull(),
+});
+
+export const rewardsRelations = relations(rewards, ({ one }) => ({
+    orders: one(orders, {
+        fields: [rewards.orderId],
+        references: [orders.id],
+    }),
+}));

--- a/src/services/payment.ts
+++ b/src/services/payment.ts
@@ -30,7 +30,10 @@ export abstract class PaymentService {
 
         return {
             transactionId: randomUUID(),
-            status: Math.random() > 0.5 ? 'approved' : 'declined',
+            status:
+                processPaymentRequest.cardDetails.cardNumber === '1111111111111111'
+                    ? 'approved'
+                    : 'declined',
         };
     }
 }

--- a/src/services/reward.ts
+++ b/src/services/reward.ts
@@ -1,0 +1,13 @@
+import { db } from '../libs/database.ts';
+import { sum } from 'drizzle-orm';
+import { rewards } from '../schema/rewards.ts';
+
+export abstract class RewardService {
+    public static async getRewardsBalance(): Promise<number> {
+        const [result] = await db
+            .select({ balance: sum(rewards.amount).mapWith(rewards.amount) })
+            .from(rewards);
+
+        return result.balance ?? 0;
+    }
+}


### PR DESCRIPTION
closes #6.

This PR adds the reward program by:
- updating the `post /api/orders` endpoint to allow the users to specify how many points they want to spend to get a discount on the total amount
- adding a new `get /rewards` endpoint to allow the user to get the current point balance